### PR TITLE
[CI] Migrate GitHub Actions from Node20 to Node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create Release
         if: github.ref_type == 'tag' && matrix.python-version == '3.9'
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: Release ${{ github.ref_name }}


### PR DESCRIPTION
## What

Upgrades deprecated/outdated GitHub Actions as part of the org-wide Node20 → Node24 runtime migration (Phase 2 & 3).

### Changes:
- `.github/workflows/ci.yml`: softprops/action-gh-release v0.1.15→v2

## Why

GitHub is enforcing the Node20 runtime for all Actions runners. Actions pinned to older major versions use deprecated Node12/Node16 runtimes and will **stop working** once enforcement begins.

- **`softprops/action-gh-release` v0.1.15 → v2**: Old version uses Node12 runtime. v2 uses Node20.

## How was this tested

- **GitHub Release (softprops)**: Push a lightweight test tag (e.g. `git tag v0.0.0-test && git push origin v0.0.0-test`). Verify the release is created with the correct assets. Clean up: delete the release and tag afterward.

### General:
- All version bumps follow the official migration guides from action maintainers
- No workflow logic was changed beyond action version tags and input name mappings
- Changes will be validated on the next workflow trigger on this branch